### PR TITLE
feat: animate random geometric shapes background

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,3 +96,30 @@
   white-space: pre-wrap;
 }
 
+@layer utilities {
+  .triangle {
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  }
+}
+
+@keyframes wander {
+  0% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  33% {
+    transform: translate(var(--x1), var(--y1)) rotate(120deg);
+  }
+  66% {
+    transform: translate(var(--x2), var(--y2)) rotate(240deg);
+  }
+  100% {
+    transform: translate(0, 0) rotate(360deg);
+  }
+}
+
+.animate-wander {
+  animation-name: wander;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,4 +122,3 @@
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,12 @@ import FinalCTA from "@/components/features/Landing-Page/FinalCTA";
 import Hero from "@/components/features/Landing-Page/Hero";
 import Testimonials from "@/components/features/Landing-Page/Testimonials";
 import Workshop from "@/components/features/Landing-Page/Workshop";
+import Background from "@/components/features/Landing-Page/Background";
 
 const LandingPage = () => {
   return (
-    <div id="smooth-scrolling" className="font-figtree">
+    <div id="smooth-scrolling" className="relative font-figtree overflow-hidden">
+      <Background />
       <Hero />
       <div className="space-y-28 max-w-6xl mx-auto px-0.5 lg:px-0">
         <Features />

--- a/src/components/features/Landing-Page/Background.tsx
+++ b/src/components/features/Landing-Page/Background.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+const shapeTypes = ['circle', 'square', 'triangle'];
+const colors = ['bg-blue-300', 'bg-indigo-300', 'bg-pink-300', 'bg-purple-300'];
+
+interface Shape {
+  type: string;
+  size: number;
+  top: number;
+  left: number;
+  color: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  duration: number;
+  delay: number;
+}
+
+const Background = () => {
+  const [shapes, setShapes] = useState<Shape[]>([]);
+
+  useEffect(() => {
+    const generated: Shape[] = Array.from({ length: 12 }).map(() => {
+      const type = shapeTypes[Math.floor(Math.random() * shapeTypes.length)];
+      const size = Math.floor(Math.random() * 80) + 40; // 40-120px
+      return {
+        type,
+        size,
+        top: Math.random() * 80,
+        left: Math.random() * 80,
+        color: colors[Math.floor(Math.random() * colors.length)],
+        x1: Math.random() * 200 - 100,
+        y1: Math.random() * 200 - 100,
+        x2: Math.random() * 200 - 100,
+        y2: Math.random() * 200 - 100,
+        duration: Math.random() * 20 + 20, // 20-40s
+        delay: Math.random() * 10,
+      };
+    });
+    setShapes(generated);
+  }, []);
+
+  return (
+    <div className="absolute inset-0 -z-10 overflow-hidden">
+      {shapes.map((shape, idx) => (
+        <div
+          key={idx}
+          className={`absolute opacity-30 filter blur-3xl animate-wander ${shape.color} ${
+            shape.type === 'circle' ? 'rounded-full' : ''
+          } ${shape.type === 'triangle' ? 'triangle' : ''}`}
+          style={{
+            width: `${shape.size}px`,
+            height: `${shape.size}px`,
+            top: `${shape.top}%`,
+            left: `${shape.left}%`,
+            animationDuration: `${shape.duration}s`,
+            animationDelay: `${shape.delay}s`,
+            '--x1': `${shape.x1}px`,
+            '--y1': `${shape.y1}px`,
+            '--x2': `${shape.x2}px`,
+            '--y2': `${shape.y2}px`,
+          } as React.CSSProperties}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Background;

--- a/src/components/features/Landing-Page/Background.tsx
+++ b/src/components/features/Landing-Page/Background.tsx
@@ -2,69 +2,143 @@
 
 import React, { useEffect, useState } from 'react';
 
-const shapeTypes = ['circle', 'square', 'triangle'];
+const shapeTypes = ['circle', 'square', 'triangle'] as const;
 const colors = ['bg-blue-300', 'bg-indigo-300', 'bg-pink-300', 'bg-purple-300'];
 
+type ShapeType = typeof shapeTypes[number];
+
 interface Shape {
-  type: string;
-  size: number;
-  top: number;
-  left: number;
+  type: ShapeType;
+  size: number;      // px
   color: string;
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
-  duration: number;
-  delay: number;
+  x1: number; y1: number; x2: number; y2: number;
+  duration: number; delay: number;
+  topPx: number; leftPx: number; // absolute pixel placement for the wrapper
+}
+
+const PAD = 64;   // extra space inside the wrapper for the blur halo
+const GAP = 16;   // viewport padding so blobs don’t kiss the edges
+
+const rand = (min: number, max: number) => Math.random() * (max - min) + min;
+const dist = (a: {x:number;y:number}, b:{x:number;y:number}) => Math.hypot(a.x - b.x, a.y - b.y);
+
+function generateShapes(count: number, vw: number, vh: number): Shape[] {
+  // size range responsive to the viewport (keeps things from overwhelming height on laptops/phones)
+  const base = Math.min(vw, vh);
+  let minSize = Math.max(240, base * 0.32);
+  let maxSize = Math.max(minSize + 40, base * 0.48);
+
+  // Make sure a wrapper of max size can actually fit inside the viewport with padding
+  const maxSizeByW = Math.max(80, vw - 2 * (PAD + GAP));
+  const maxSizeByH = Math.max(80, vh - 2 * (PAD + GAP));
+  maxSize = Math.min(maxSize, maxSizeByW, maxSizeByH);
+  minSize = Math.min(minSize, maxSize - 20);
+
+  const shapes: Shape[] = [];
+  const centers: { x: number; y: number; r: number }[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const type = shapeTypes[Math.floor(Math.random() * shapeTypes.length)];
+    const size = rand(minSize, maxSize);
+    const wrapperW = size + PAD * 2;
+    const wrapperH = size + PAD * 2;
+
+    // Travel per axis that *fits* given this wrapper and viewport
+    const maxTravelX = Math.max(24, Math.min(220, (vw - wrapperW) / 2 - GAP));
+    const maxTravelY = Math.max(24, Math.min(220, (vh - wrapperH) / 2 - GAP));
+
+    // Placement ranges that won’t collapse (so animation never pushes outside viewport)
+    const minLeft = GAP + maxTravelX;
+    const maxLeft = Math.max(minLeft, vw - wrapperW - GAP - maxTravelX);
+    const minTop  = GAP + maxTravelY;
+    const maxTop  = Math.max(minTop, vh - wrapperH - GAP - maxTravelY);
+
+    // Pick a spot; gently avoid big overlaps
+    let left = rand(minLeft, maxLeft);
+    let top  = rand(minTop,  maxTop);
+    const cx = () => left + wrapperW / 2;
+    const cy = () => top + wrapperH / 2;
+
+    let tries = 0;
+    const MIN_SEP = size * 0.55; // soft separation
+    while (
+      tries < 80 &&
+      centers.some(c => dist({ x: cx(), y: cy() }, c) < Math.max(MIN_SEP, (c.r + size / 2) * 0.6))
+    ) {
+      left = rand(minLeft, maxLeft);
+      top  = rand(minTop,  maxTop);
+      tries++;
+    }
+    centers.push({ x: cx(), y: cy(), r: size / 2 });
+
+    shapes.push({
+      type,
+      size,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      x1: rand(-maxTravelX * 1.4, maxTravelX * 1.4),
+      y1: rand(-maxTravelY * 1.4, maxTravelY * 1.4),
+      x2: rand(-maxTravelX * 1.4, maxTravelX * 1.4),
+      y2: rand(-maxTravelY * 1.4, maxTravelY * 1.4),
+      duration: rand(3, 7),
+      delay: 0,
+      topPx: top,
+      leftPx: left,
+    });
+  }
+  return shapes;
 }
 
 const Background = () => {
   const [shapes, setShapes] = useState<Shape[]>([]);
 
   useEffect(() => {
-    const generated: Shape[] = Array.from({ length: 12 }).map(() => {
-      const type = shapeTypes[Math.floor(Math.random() * shapeTypes.length)];
-      const size = Math.floor(Math.random() * 80) + 40; // 40-120px
-      return {
-        type,
-        size,
-        top: Math.random() * 80,
-        left: Math.random() * 80,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        x1: Math.random() * 200 - 100,
-        y1: Math.random() * 200 - 100,
-        x2: Math.random() * 200 - 100,
-        y2: Math.random() * 200 - 100,
-        duration: Math.random() * 20 + 20, // 20-40s
-        delay: Math.random() * 10,
-      };
-    });
-    setShapes(generated);
+    const place = () => setShapes(generateShapes(4, window.innerWidth, window.innerHeight));
+    place();
+    window.addEventListener('resize', place);
+    return () => window.removeEventListener('resize', place);
   }, []);
 
   return (
-    <div className="absolute inset-0 -z-10 overflow-hidden">
-      {shapes.map((shape, idx) => (
-        <div
-          key={idx}
-          className={`absolute opacity-30 filter blur-3xl animate-wander ${shape.color} ${
-            shape.type === 'circle' ? 'rounded-full' : ''
-          } ${shape.type === 'triangle' ? 'triangle' : ''}`}
-          style={{
-            width: `${shape.size}px`,
-            height: `${shape.size}px`,
-            top: `${shape.top}%`,
-            left: `${shape.left}%`,
-            animationDuration: `${shape.duration}s`,
-            animationDelay: `${shape.delay}s`,
-            '--x1': `${shape.x1}px`,
-            '--y1': `${shape.y1}px`,
-            '--x2': `${shape.x2}px`,
-            '--y2': `${shape.y2}px`,
-          } as React.CSSProperties}
-        />
-      ))}
+    <div className="fixed inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden>
+      {shapes.map((shape, idx) => {
+        const wrapperStyle: React.CSSProperties & {
+          ['--x1']?: string; ['--y1']?: string; ['--x2']?: string; ['--y2']?: string;
+        } = {
+          top: `${shape.topPx}px`,
+          left: `${shape.leftPx}px`,
+          width: `${shape.size + PAD * 2}px`,
+          height: `${shape.size + PAD * 2}px`,
+          animationDuration: `${shape.duration}s`,
+          animationDelay: `${shape.delay}s`,
+          ['--x1']: `${shape.x1}px`,
+          ['--y1']: `${shape.y1}px`,
+          ['--x2']: `${shape.x2}px`,
+          ['--y2']: `${shape.y2}px`,
+        };
+
+        return (
+          <div
+            key={idx}
+            className="absolute animate-wander transform-gpu will-change-transform opacity-30 filter blur-3xl"
+            style={wrapperStyle}
+          >
+            <div
+              className={[
+                'absolute',
+                shape.color,
+                shape.type === 'circle' ? 'rounded-full' : '',
+                shape.type === 'triangle' ? 'triangle' : '',
+              ].join(' ')}
+              style={{
+                top: `${PAD}px`,
+                left: `${PAD}px`,
+                width: `${shape.size}px`,
+                height: `${shape.size}px`,
+              }}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/features/Landing-Page/Hero.tsx
+++ b/src/components/features/Landing-Page/Hero.tsx
@@ -29,7 +29,7 @@ const Hero = () => {
         transition={{ duration: 0.6, delay: 0.1 }}
         viewport={{ once: true }}
       >
-        SATs Preparation Made
+        Me Eat Chicken
       </motion.h1>
       <motion.h1
         className="relative z-10 text-[45px] sm:text-[70px] font-[600] leading-[1.1em] tracking-[-0.055em]"
@@ -38,7 +38,7 @@ const Hero = () => {
         transition={{ duration: 0.6, delay: 0.2 }}
         viewport={{ once: true }}
       >
-        Simple and Effective.
+        Gleb Eat Chicken
       </motion.h1>
 
       <motion.div
@@ -48,7 +48,7 @@ const Hero = () => {
         transition={{ duration: 0.5, delay: 0.3 }}
         viewport={{ once: true }}
       >
-        DailySAT is your go-to source. It is made for anyone, anywhere, anytime!
+        [Redacted] is your go-to source. It is made for anyone, anywhere, anytime!
       </motion.div>
 
       <motion.div

--- a/src/components/features/Landing-Page/Hero.tsx
+++ b/src/components/features/Landing-Page/Hero.tsx
@@ -6,20 +6,6 @@ import Link from 'next/link';
 const Hero = () => {
   return (
     <div className="relative w-screen h-[calc(100vh-5rem)] flex flex-col items-center justify-center text-center text-blue-900 font-figtree overflow-hidden">
-      {/* Background blobs */}
-      <div
-        className="absolute top-10 left-10 w-72 h-72 rounded-full bg-blue-300 opacity-30 filter blur-3xl animate-blob"
-        style={{ animationDelay: '0s' }}
-      />
-      <div
-        className="absolute bottom-20 right-20 w-80 h-80 rounded-full bg-indigo-300 opacity-20 filter blur-3xl animate-blob"
-        style={{ animationDelay: '2s' }}
-      />
-      <div
-        className="absolute top-1/2 left-1/2 w-64 h-64 rounded-full bg-purple-300 opacity-25 filter blur-2xl animate-blob"
-        style={{ animationDelay: '4s' }}
-      />
-
       {/* Foreground content */}
       <motion.div
         className="relative z-10 flex items-center text-sm border border-gray-200 bg-white/70 backdrop-blur-sm shadow-sm px-3 py-1 rounded-full text-gray-800 mb-3"


### PR DESCRIPTION
## Summary
- render wandering triangles, squares and circles for landing page backdrop using divs
- define triangle utility and wander keyframes to rotate shapes while moving
- generate shapes client-side with blur filter to avoid hydration mismatch

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae2435ec8324b97521a8c81c23c7