### PR TITLE
feat: animate hero tagline with rotating slider

### DIFF
--- a/src/components/features/Landing-Page/Features.tsx
+++ b/src/components/features/Landing-Page/Features.tsx
@@ -6,7 +6,7 @@ import { featureList } from '@/data/landing-page/features'
 
 const Features = () => {
   return (
-    <div>
+    <div id="how-it-works">
       <Header 
         badgeText="Our Features"
         text="Tools designed for teens"

--- a/src/components/features/Landing-Page/Hero.tsx
+++ b/src/components/features/Landing-Page/Hero.tsx
@@ -80,7 +80,7 @@ const Hero = () => {
       >
         <span>Whether you're </span>
         <span
-          className="relative inline-flex w-64 h-[1.6em] items-center justify-center overflow-hidden bg-gray-100 border border-gray-300 rounded-md mx-1"
+          className="relative inline-flex w-80 h-[1.6em] items-center justify-center overflow-hidden bg-gray-100 border border-gray-300 rounded-md mx-1"
         >
           <AnimatePresence mode="wait">
             <motion.span
@@ -109,7 +109,7 @@ const Hero = () => {
           href="/dashboard"
           className="text-sm bg-blue-500 text-white py-2 px-4 rounded-lg flex items-center group"
         >
-          Dashboard
+          Start Your Journey
           <ArrowSvg
             className="w-4 h-4 ml-2 transition-transform duration-300 -rotate-45 group-hover:rotate-0"
             stroke="white"
@@ -117,10 +117,10 @@ const Hero = () => {
         </Link>
 
         <Link
-          href="/team"
+          href="#how-it-works"
           className="text-sm border border-gray-600 text-black py-2 px-4 rounded-lg flex items-center group"
         >
-          View our team
+          See How It Works
         </Link>
       </motion.div>
     </div>

--- a/src/components/features/Landing-Page/Hero.tsx
+++ b/src/components/features/Landing-Page/Hero.tsx
@@ -79,7 +79,9 @@ const Hero = () => {
         viewport={{ once: true }}
       >
         <span>Whether you're </span>
-        <span className="relative inline-block h-[1.2em] overflow-hidden">
+        <span
+          className="relative inline-flex w-64 h-[1.6em] items-center justify-center overflow-hidden bg-gray-100 border border-gray-300 rounded-md mx-1"
+        >
           <AnimatePresence mode="wait">
             <motion.span
               key={phrases[index]}
@@ -87,7 +89,7 @@ const Hero = () => {
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: '-100%', opacity: 0 }}
               transition={{ duration: 0.5 }}
-              className="block"
+              className="block w-full text-center"
             >
               {phrases[index]}
             </motion.span>

--- a/src/components/features/Landing-Page/Hero.tsx
+++ b/src/components/features/Landing-Page/Hero.tsx
@@ -1,9 +1,25 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import ArrowSvg from '@/components/common/icons/ArrowSVG';
 import Link from 'next/link';
 
 const Hero = () => {
+  const phrases = [
+    'a 1500+ warrior',
+    'struggling with SAT English',
+    'procrastinating starting studying',
+    "can't get a grip on SAT math",
+  ];
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setIndex((i) => (i + 1) % phrases.length),
+      2500
+    );
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <div className="relative w-screen h-[calc(100vh-5rem)] flex flex-col items-center justify-center text-center text-blue-900 font-figtree overflow-hidden">
       {/* Background blobs */}
@@ -62,7 +78,22 @@ const Hero = () => {
         transition={{ duration: 0.5, delay: 0.3 }}
         viewport={{ once: true }}
       >
-        DailySAT is your go-to source. It is made for anyone, anywhere, anytime!
+        <span>Whether you're </span>
+        <span className="relative inline-block h-[1.2em] overflow-hidden">
+          <AnimatePresence mode="wait">
+            <motion.span
+              key={phrases[index]}
+              initial={{ y: '100%', opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: '-100%', opacity: 0 }}
+              transition={{ duration: 0.5 }}
+              className="block"
+            >
+              {phrases[index]}
+            </motion.span>
+          </AnimatePresence>
+        </span>
+        <span>, we've got you with a plan, motivation, support, and results.</span>
       </motion.div>
 
       <motion.div


### PR DESCRIPTION
## Summary
- add animated slider to hero tagline that cycles through SAT prep scenarios
- replace static copy with motivational message

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62d93299c8324bbf6ee1a098bf62d